### PR TITLE
chore:issueテンプレートの追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,13 @@
+name: バグ報告
+description: 不具合を報告します
+title: "[Bug] "
+labels: ["bug"]
+
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: 不具合の内容
+      description: どんな問題が起きているか、簡潔に書いてください
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+name: 機能提案
+description: 新しい機能や改善点の提案はこちら
+title: "[Feature] "
+labels: ["enhancement"]
+
+body:
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 提案の内容
+      description: どんな機能・改善をしたいか書いてください
+    validations:
+      required: true


### PR DESCRIPTION
課題

- issue作成のテンプレートがなかった

対応

- バグ対応・新機能追加用のテンプレートを作成した

今後

- 実際に使うテンプレートを検討し、テンプレートを再作成してもいい
- テンプレートは最小限にしたので、今後構成を検討
- Issue作成がGithub側になる事、IssueやPRのテンプレートはGithub側でないと使えない事から、Githubを中心に作業するか検討